### PR TITLE
Add unit tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,10 +4,7 @@ const config: Config = {
   preset: 'jest-preset-angular',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
-  transform: {
-    '^.+\\.m?[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
-  },
-  moduleFileExtensions: ['ts', 'html', 'js'],
+  moduleFileExtensions: ['ts', 'html', 'js', 'mjs'],
   coverageDirectory: 'coverage',
 };
 export default config;

--- a/src/app/components/history.component.spec.ts
+++ b/src/app/components/history.component.spec.ts
@@ -1,0 +1,50 @@
+import { signal } from '@angular/core';
+import { HistoryComponent } from './history.component';
+import { TimerService, Timer } from '../services/timer.service';
+import { HistoryService, TimerHistory } from '../services/history.service';
+
+class MockTimerService {
+  timers = signal<Timer[]>([]);
+  cancel = jest.fn();
+}
+
+class MockHistoryService {
+  history = signal<TimerHistory[]>([]);
+}
+
+describe('HistoryComponent', () => {
+  let component: HistoryComponent;
+  let timerSvc: MockTimerService;
+
+  beforeEach(() => {
+    timerSvc = new MockTimerService();
+    const historySvc = new MockHistoryService();
+    component = new HistoryComponent(historySvc as any, timerSvc as any);
+  });
+
+  it('calculates progress percent', () => {
+    const timer: Timer = {
+      id: 1,
+      title: 't',
+      totalMs: 1000,
+      remainingMs: 500,
+      start: new Date(),
+      end: new Date(),
+      running: true
+    };
+    expect(component.progress(timer)).toBe(50);
+  });
+
+  it('formats remaining time', () => {
+    expect(component.display(90000)).toBe('01:30');
+  });
+
+  it('delegates cancel to service', () => {
+    component.cancel(42);
+    expect(timerSvc.cancel).toHaveBeenCalledWith(42);
+  });
+
+  it('formats elapsed time', () => {
+    expect(component.format(61000)).toBe('1 minute 1 second');
+  });
+});

--- a/src/app/components/timer-form.component.spec.ts
+++ b/src/app/components/timer-form.component.spec.ts
@@ -9,7 +9,7 @@ describe('TimerFormComponent', () => {
     await render(TimerFormComponent, {
       providers: [TimerService, HistoryService, NotificationService]
     });
-    const button = screen.getByRole('button', { name: /set/i });
-    expect(button).toBeDisabled();
+    const button = screen.getByRole('button', { name: /set/i }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
   });
 });

--- a/src/app/services/history.service.spec.ts
+++ b/src/app/services/history.service.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed } from '@angular/core/testing';
+import { HistoryService } from './history.service';
+
+describe('HistoryService', () => {
+  let service: HistoryService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [HistoryService] });
+    service = TestBed.inject(HistoryService);
+  });
+
+  it('adds entry to history', () => {
+    expect(service.history().length).toBe(0);
+    service.add({
+      title: 'test',
+      elapsedMs: 1000,
+      totalMs: 1000,
+      start: new Date(0),
+      end: new Date(1000)
+    });
+    expect(service.history().length).toBe(1);
+    expect(service.history()[0].title).toBe('test');
+  });
+});

--- a/src/app/services/notification.service.spec.ts
+++ b/src/app/services/notification.service.spec.ts
@@ -1,0 +1,31 @@
+import { NotificationService } from './notification.service';
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+
+  beforeEach(() => {
+    service = new NotificationService();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (global as any).Notification;
+  });
+
+  it('uses Notification API when permission is granted', () => {
+    const notifySpy = jest.fn();
+    (global as any).Notification = function (msg: string) {
+      notifySpy(msg);
+    } as any;
+    (global as any).Notification.permission = 'granted';
+    service.notify('hello');
+    expect(notifySpy).toHaveBeenCalledWith('hello');
+  });
+
+  it('falls back to alert when Notification is unavailable', () => {
+    const alertSpy = jest.fn();
+    (global as any).alert = alertSpy;
+    service.notify('fallback');
+    expect(alertSpy).toHaveBeenCalledWith('fallback');
+  });
+});

--- a/src/app/services/timer.service.spec.ts
+++ b/src/app/services/timer.service.spec.ts
@@ -11,10 +11,12 @@ describe('TimerService', () => {
     TestBed.configureTestingModule({ providers: [TimerService, HistoryService, NotificationService] });
     service = TestBed.inject(TimerService);
     history = TestBed.inject(HistoryService);
+    (global as any).alert = jest.fn();
     jest.useFakeTimers();
   });
 
   afterEach(() => {
+    delete (global as any).alert;
     jest.useRealTimers();
   });
 
@@ -24,5 +26,13 @@ describe('TimerService', () => {
     jest.advanceTimersByTime(1000);
     expect(service.timers().length).toBe(0);
     expect(history.history().length).toBe(1);
+  });
+
+  it('cancels a running timer', () => {
+    service.start('t', 0, 5);
+    const id = service.timers()[0].id;
+    service.cancel(id);
+    expect(service.timers().length).toBe(0);
+    expect(history.history().length).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- fix Jest config to rely on preset defaults
- cover HistoryService with tests
- test HistoryComponent logic
- test NotificationService fallback and API usage
- test timer cancellation
- fix TimerForm test to check disabled state without jest-dom

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686acf72b2608327acc92bc1eb7d85a6